### PR TITLE
AB#1222 Create a GlobalVariable reset function

### DIFF
--- a/src/main/java/gamecontrol/GlobalVariables.java
+++ b/src/main/java/gamecontrol/GlobalVariables.java
@@ -5,6 +5,7 @@ import gamecontrol.contents.CrewMember;
 import gamecontrol.contents.Enemy;
 import gamecontrol.contents.Inventory;
 import gamecontrol.contents.Item;
+import gamemodel.combatengine.EngageEnemy;
 import gamemodel.mapengine.MainMap;
 import gamemodel.mapengine.SubArea;
 
@@ -19,6 +20,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+
+import ui.gui.ConstructHTMLString;
 import ui.maps.UIEnterSubarea;
 
 
@@ -31,7 +34,7 @@ public class GlobalVariables {
 
     public static final String DESTINATION = "Schrader Lab";
 
-    public static final Enemy FINAL_BOSS =
+    public static Enemy FINAL_BOSS =
         new Enemy("patient zero", 1200, 20, "zombie");
 
     public static boolean defeatBoss = false;
@@ -280,5 +283,33 @@ public class GlobalVariables {
             miniBoss = inGameMap.newEnemy(miniBossTemplate.getName());
             enemiesTemplateCollection.remove(miniBossTemplate);
         }
+    }
+
+    public static void resetGlobalVariables() {
+        FINAL_BOSS = new Enemy("patient zero", 1200, 20, "zombie");
+        defeatBoss = false;
+        miniBoss = new Enemy();
+        finalBoss = new Enemy();
+        DROP_RATE_MAP = new HashMap<>();
+        inGameCommands = new HashMap<>();
+        currentSubAreaContents = new SubArea();
+        inGameMap = null;
+        InventoryMap = new HashMap<>();
+        mySquad = new ArrayList<>();
+        enemySquad = new ArrayList<>();
+        subAreaTemplatesCollection = new ArrayList<>();
+        enemiesTemplateCollection = new ArrayList<>();
+        mySquadTemplate = new ArrayList<>();
+        itemTemplatesCollection = new Inventory();
+        combatCommandDescription = new HashMap<>();
+        passWord = null;
+
+        // ui.gui
+        ConstructHTMLString.HAS_PASSWORD = false;
+
+        // gamemodel.combatengine
+        EngageEnemy.setKIAList(new ArrayList<>());
+        EngageEnemy.setEnemyKIAList(new ArrayList<>());
+        EngageEnemy.setSummonedMinion(new ArrayList<>());
     }
 }

--- a/src/main/java/gamemodel/combatengine/EngageEnemy.java
+++ b/src/main/java/gamemodel/combatengine/EngageEnemy.java
@@ -291,7 +291,10 @@ public class EngageEnemy {
         }
     }
 
-    public static List<Enemy> getEnemyKIAList() {
-        return enemyKIAList;
-    }
+    public static List<Enemy> getEnemyKIAList() {return enemyKIAList;}
+    public static List<CrewMember> getKIAList() {return KIAList;}
+    public static void setKIAList(List<CrewMember> KIAList) {EngageEnemy.KIAList = KIAList;}
+    public static void setEnemyKIAList(List<Enemy> enemyKIAList) {EngageEnemy.enemyKIAList = enemyKIAList;}
+    public static List<Enemy> getSummonedMinion() {return summonedMinion;}
+    public static void setSummonedMinion(List<Enemy> summonedMinion) {EngageEnemy.summonedMinion = summonedMinion;}
 }

--- a/src/main/java/gamemodel/combatengine/GUICombatEngine.java
+++ b/src/main/java/gamemodel/combatengine/GUICombatEngine.java
@@ -69,12 +69,11 @@ public class GUICombatEngine {
 
     public String initiativeResultString() {
         JFrame frame = (JFrame) getCombatPanel().getTopLevelAncestor();
-        if(GlobalVariables.enemySquad.isEmpty()) {
+        boolean lose = JOptionPanes.youLosePane(frame);
+        boolean win = JOptionPanes.youWinPane(frame);
+        if(GlobalVariables.enemySquad.isEmpty() && !lose && !win) {
             JOptionPanes.combatWon(frame);
             getCombatPanel().backToMap();
-        } else {
-            JOptionPanes.youLosePane(frame);
-            JOptionPanes.youWinPane(frame);
         }
         setRoundInitiative(determineRoundInitiative());
         return UICombat.reportInitiativeStatus(getRoundInitiative());

--- a/src/main/java/ui/gui/components/JOptionPanes.java
+++ b/src/main/java/ui/gui/components/JOptionPanes.java
@@ -11,14 +11,14 @@ import static java.lang.System.exit;
 
 public class JOptionPanes {
 
-    public static void youLosePane(JFrame frame) {
+    public static boolean youLosePane(JFrame frame) {
         if(GlobalVariables.mySquad.get(0).getHP() <= 0) {
             int i = JOptionPane.showConfirmDialog(frame,
                     "You died! Do you want to play again?",
                     "You Lose!",
                     JOptionPane.YES_NO_OPTION);
             if(i == JOptionPane.YES_OPTION) {
-                GlobalVariables.mySquad.get(0).setHP(100);
+                GlobalVariables.resetGlobalVariables();
                 frame.getContentPane().removeAll();
                 frame.add(new TitlePanel());
                 frame.repaint();
@@ -26,17 +26,19 @@ public class JOptionPanes {
             } else {
                 exit(0);
             }
+            return true;
         }
+        return false;
     }
 
-    public static void youWinPane(JFrame frame) {
+    public static boolean youWinPane(JFrame frame) {
         if(EngageEnemy.getEnemyKIAList().stream().anyMatch(ex -> ex.getName().equals(FINAL_BOSS.getName()))) {
             int i = JOptionPane.showConfirmDialog(frame,
                     "You won! You found and defeated Patient Zero!\nDo you want to play again?",
                     "You Win!",
                     JOptionPane.YES_NO_OPTION);
             if(i == JOptionPane.YES_OPTION) {
-                GlobalVariables.mySquad.get(0).setHP(100);
+                GlobalVariables.resetGlobalVariables();
                 frame.getContentPane().removeAll();
                 frame.add(new TitlePanel());
                 frame.repaint();
@@ -44,7 +46,9 @@ public class JOptionPanes {
             } else {
                 exit(0);
             }
+            return true;
         }
+        return false;
     }
 
     public static void combatWon(JFrame frame) {

--- a/src/main/java/ui/gui/components/buttons/ExitToMainMenuButton.java
+++ b/src/main/java/ui/gui/components/buttons/ExitToMainMenuButton.java
@@ -26,8 +26,7 @@ public class ExitToMainMenuButton extends JButton {
             JFrame parentFrame = window.getParentFrame();
             window.dispose();
 
-            // TODO Implement proper reset of the game
-            GlobalVariables.mySquad.get(0).setHP(100);
+            GlobalVariables.resetGlobalVariables();
             parentFrame.getContentPane().removeAll();
             parentFrame.repaint();
             parentFrame.add(new TitlePanel());

--- a/src/main/java/ui/gui/components/panels/TitlePanel.java
+++ b/src/main/java/ui/gui/components/panels/TitlePanel.java
@@ -76,6 +76,7 @@ public class TitlePanel extends JPanel {
 
 
 
+    @Deprecated
     public static void main(String[] args) {
         JFrame window = new JFrame();
         window.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);


### PR DESCRIPTION
Reset method implemented to reset all the global variables 
This is called whenever the user returns to main menu from game 

[AB#1244](https://dev.azure.com/2210SDI10/ea5dda2c-6b93-474b-926e-ad2de84f2aec/_workitems/edit/1244) Reorganized logic to check if user wins/loses 
Method will return true/false
backToMap() method will only be called if those two are false 

Deprecated psvm on TitlePanel since StrainXMain runs program now